### PR TITLE
fix accidental tor thread concurrency

### DIFF
--- a/Chaincase.iOS/Tor/TorProcessManager.cs
+++ b/Chaincase.iOS/Tor/TorProcessManager.cs
@@ -29,7 +29,7 @@ namespace Chaincase.iOS.Tor
     public class OnionManager : ITorManager
     {
 
-        private NSData Cookie; 
+        private NSData Cookie => NSData.FromUrl(torBaseConf.DataDirectory.Append("control_auth_cookie", false));
         public TorState State { get; set; }
         private DispatchBlock initRetry;
 
@@ -37,7 +37,6 @@ namespace Chaincase.iOS.Tor
         {
             TorSocks5EndPoint = new IPEndPoint(IPAddress.Loopback, 9050);
             TorController = null;
-            Cookie = NSData.FromUrl(torBaseConf.DataDirectory.Append("control_auth_cookie", false));
         }
 
         /// <summary>

--- a/Chaincase.iOS/Tor/TorProcessManager.cs
+++ b/Chaincase.iOS/Tor/TorProcessManager.cs
@@ -140,7 +140,7 @@ namespace Chaincase.iOS.Tor
                     if (success)
                     {
                         NSObject completeObs = null;
-                        completeObs = TorController.AddObserverForCircuitEstablished((established) =>
+                        completeObs = TorController?.AddObserverForCircuitEstablished((established) =>
                         {
                             if (established) {
                                 State = TorState.Connected;
@@ -182,7 +182,8 @@ namespace Chaincase.iOS.Tor
                 });
             }); //delay
 
-            initRetry = new DispatchBlock(() => {
+            initRetry = new DispatchBlock(() =>
+            {
                 Logger.LogDebug("Triggering Tor connection retry.");
 
                 TorController?.SetConfForKey("DisableNetwork", "1", null);
@@ -194,7 +195,7 @@ namespace Chaincase.iOS.Tor
 
             // On first load: If Tor hasn't finished bootstrap in 30 seconds,
             // HUP tor once in case we have partially bootstrapped but got stuck.
-            DispatchQueue.MainQueue.DispatchAfter(new DispatchTime(DispatchTime.Now, TimeSpan.FromSeconds(15)), initRetry);
+            DispatchQueue.MainQueue.DispatchAfter(new DispatchTime(DispatchTime.Now, TimeSpan.FromSeconds(15)), initRetry!);
         }
 
         private TORConfiguration torBaseConf

--- a/Chaincase.iOS/Tor/TorProcessManager.cs
+++ b/Chaincase.iOS/Tor/TorProcessManager.cs
@@ -254,14 +254,16 @@ namespace Chaincase.iOS.Tor
         {
             Logger.LogDebug($"{this} #stopAsync");
 
-            // Under the hood, TORController will SIGNAL SHUTDOWN and set it's channel to nil, so
+            // Under the hood, TORController will SIGNAL SHUTDOWN and set it's channel to null, so
             // we actually rely on that to stop Tor and reset the state of torController. (we can
             // SIGNAL SHUTDOWN here, but we can't reset the torController "isConnected" state.)
             TorController?.Disconnect();
             TorController?.Dispose();
+            TorController = null;
 
             torThread?.Cancel();
             torThread?.Dispose();
+            torThread = null;
 
             State = TorState.Stopped;
         }

--- a/Chaincase/App.xaml.cs
+++ b/Chaincase/App.xaml.cs
@@ -27,7 +27,18 @@ namespace Chaincase
 		{
 			InitializeComponent();
 			Global = new Global();
-			Task.Run(async () => { await Global.InitializeNoWalletAsync().ConfigureAwait(false); });
+			Task.Run(async () =>
+			{
+				try
+				{
+					await Global.InitializeNoWalletAsync().ConfigureAwait(false);
+				}
+				catch (OperationCanceledException ex)
+				{
+					Logger.LogTrace(ex);
+				}
+			});
+
 			Locator.CurrentMutable.RegisterConstant(Global);
 
 			Locator

--- a/Chaincase/Global.cs
+++ b/Chaincase/Global.cs
@@ -723,7 +723,8 @@ namespace Chaincase
 
 				int maxFiltSyncCount = Network == Network.Main ? 1000 : 10000; // On testnet, filters are empty, so it's faster to query them together
 
-				Synchronizer.Start(requestInterval, TimeSpan.FromMinutes(5), maxFiltSyncCount);
+                Synchronizer = new WasabiSynchronizer(Network, BitcoinStore, () => Config.GetCurrentBackendUri(), Config.TorSocks5EndPoint);
+                Synchronizer.Start(requestInterval, TimeSpan.FromMinutes(5), maxFiltSyncCount);
 				Logger.LogInfo("Start synchronizing filters...");
 			}
             catch (OperationCanceledException ex)

--- a/Chaincase/Global.cs
+++ b/Chaincase/Global.cs
@@ -666,8 +666,6 @@ namespace Chaincase
             return !StoppingCts.IsCancellationRequested;
         }
 
-        private bool inStartupPhase = true;
-
         public async Task OnResuming()
 		{
             ResumeCompleted = false;
@@ -684,12 +682,9 @@ namespace Chaincase
                 cancel.ThrowIfCancellationRequested();
 
                 var tor = DependencyService.Get<ITorManager>();
-				if (!inStartupPhase && tor?.State != TorState.Started && tor.State != TorState.Connected)
+				if (tor?.State != TorState.Started && tor.State != TorState.Connected)
 				{
 					tor.Start(false, GetDataDir());
-				} else
-				{
-                    inStartupPhase = false;
 				}
 
                 cancel.ThrowIfCancellationRequested();

--- a/Chaincase/Global.cs
+++ b/Chaincase/Global.cs
@@ -152,9 +152,6 @@ namespace Chaincase
                     TorManager.Start(ensureRunning: true, "mock");
                 }
 
-                var fallbackRequestTestUri = new Uri(Config.GetFallbackBackendUri(), "/api/software/versions");
-                TorManager.StartMonitor(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(7), DataDir, fallbackRequestTestUri);
-
                 Logger.LogInfo($"{nameof(TorManager)} is initialized.");
 
                 #endregion TorProcessInitialization

--- a/Chaincase/ITorManager.cs
+++ b/Chaincase/ITorManager.cs
@@ -20,8 +20,6 @@ namespace Chaincase
 
         ITorManager Mock();
 
-        public void StartMonitor(TimeSpan torMisbehaviorCheckPeriod, TimeSpan checkIfRunningAfterTorMisbehavedFor, string dataDirToStartWith, Uri fallBackTestRequestUri);
-
         Task StopAsync();
     }
 }

--- a/Chaincase/ViewModels/StatusViewModel.cs
+++ b/Chaincase/ViewModels/StatusViewModel.cs
@@ -89,7 +89,14 @@ namespace Chaincase.ViewModels
                 })
                 .ToProperty(this, x => x.ProgressPercent);
 
-            Global.Initialized += OnInitialized;
+            if (Global.IsInitialized)
+            {
+                OnInitialized(this, EventArgs.Empty);
+            }
+            else
+            {
+                Global.Initialized += OnInitialized;
+            }
 
             Peers = Tor == TorStatus.NotRunning ? 0 : Nodes.Count;
 


### PR DESCRIPTION
Spin up the app, then background it quickly and it crashes #68 . The crash is typically called because there can only be 1 (objective-c Tor.framework defined) TORThread per process and somewhere another is created.

I think there may be another issue where the `StartMonitor()` function is not called which I'll document here because I don't have it defined and reproducable yet.

#### tor embed arch

[Tor.framework ](https://github.com/iCepa/Tor.framework) binary and header files are packaged and bound to C# in the project of the same name. The Tor process lifecycle is managed in TorProcessManager.cs by combining management from the [Tor Project's iOS app manager](https://github.com/OnionBrowser/OnionBrowser/blob/2.X/OnionBrowser/OnionManager.swift) and [Wasabi's TorProcessManager](https://github.com/zkSNACKs/WalletWasabi/blob/f8d5a8d263a6ba393f3828f84bdcbe28d2f54d86/WalletWasabi/Tor/TorProcessManager.cs). Without an abstracted Tor `Process`, that logic made it's way into this class and is the mess to be revised