### PR TITLE
Fix Share SSB v2

### DIFF
--- a/Chaincase.SSB/SSBShare.cs
+++ b/Chaincase.SSB/SSBShare.cs
@@ -27,7 +27,7 @@ namespace Chaincase.SSB
 		public async Task ShareText(string text, string title = null)
 		{
 			// only supported on a few select browsers https://caniuse.com/mdn-api_navigator_share
-			await _jsRuntime.InvokeVoidAsync("executeFunctionByName", "window", "navigator.share", new
+			await _jsRuntime.InvokeVoidAsync("IonicBridge.executeFunctionByName", "window", "navigator.share", new
 			{
 				title,
 				text

--- a/Chaincase.UI/wwwroot/global.js
+++ b/Chaincase.UI/wwwroot/global.js
@@ -1,0 +1,19 @@
+function dispatchEventWrapper(evt) {
+  window.dispatchEvent(new CustomEvent(evt))
+}
+
+if (!navigator.share && navigator.clipboard) {
+  navigator.share = (data) => {
+    const toast = document.createElement('ion-toast');
+    toast.message = data.title ? `${data.title} copied to clipboard` : 'Copied to clipboard';
+    toast.duration = 2000;
+    navigator.clipboard.writeText(data.text || data.url).catch(reason => console.error(reason));
+    document.body.appendChild(toast);
+    return toast.present();
+  }
+} else if (!navigator.share) {
+  navigator.share = (data) => {
+    console.warn("Wanted to use share API but not supported on this platform.", data);
+    return Promise.resolve();
+  }
+}


### PR DESCRIPTION
was too hasty with the fix, needed to specify IonicBridge as the parent of the func. Also included a fallback toast + clipboard copy for other browser where the Share API is not supported (need to add globa.js to index html pages but this is done in other PRs so let's avoid that merge conflict)