### PR TITLE
keep synchronizer initialized OnSleep

### DIFF
--- a/Chaincase.Common/Chaincase.Common.csproj
+++ b/Chaincase.Common/Chaincase.Common.csproj
@@ -8,9 +8,9 @@
       <ProjectReference Include="..\WalletWasabi\WalletWasabi.Standard\WalletWasabi.Standard.csproj" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="NBitcoin" Version="5.0.75" />
       <PackageReference Include="ReactiveUI" Version="13.2.2" />
       <PackageReference Include="ReactiveUI.Blazor" Version="13.2.2" />
+      <PackageReference Include="NBitcoin" Version="5.0.76" />
     </ItemGroup>
     <ItemGroup>
       <Folder Include="Models\" />

--- a/Chaincase.Common/ChaincaseSynchronizer.cs
+++ b/Chaincase.Common/ChaincaseSynchronizer.cs
@@ -32,7 +32,7 @@ namespace Chaincase.Common.Services
 			Cancel?.Cancel();
 			while (Interlocked.CompareExchange(ref _running, 3, 0) == 2)
 			{
-				await Task.Delay(50);
+				await Task.Delay(50); // wait for Start() loop to Cancel
 			}
 			Cancel?.Dispose();
 			Cancel = null;
@@ -40,7 +40,7 @@ namespace Chaincase.Common.Services
 
 		public void Resume(TimeSpan requestInterval, TimeSpan feeQueryRequestInterval, int maxFiltersToSyncAtInitialization)
 		{
-			Interlocked.CompareExchange(ref _running, 3, 1); // if stopped, make it running
+			Interlocked.CompareExchange(ref _running, 0, 3); // If stopped, make it not started
 			Cancel = new CancellationTokenSource();
 			Start(requestInterval, feeQueryRequestInterval, maxFiltersToSyncAtInitialization);
 		}

--- a/Chaincase.Common/ChaincaseSynchronizer.cs
+++ b/Chaincase.Common/ChaincaseSynchronizer.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using NBitcoin;
+using WalletWasabi.Services;
+using WalletWasabi.Stores;
+using WalletWasabi.WebClients.Wasabi;
+
+namespace Chaincase.Common.Services
+{
+	public class ChaincaseSynchronizer : WasabiSynchronizer
+	{
+		public ChaincaseSynchronizer(Network network, BitcoinStore bitcoinStore, WasabiClient client)
+			: base(network, bitcoinStore, client)
+		{
+		}
+
+		public ChaincaseSynchronizer(Network network, BitcoinStore bitcoinStore, Func<Uri> baseUriAction, EndPoint torSocks5EndPoint)
+			: base(network, bitcoinStore, baseUriAction, torSocks5EndPoint)
+		{
+		}
+
+		public ChaincaseSynchronizer(Network network, BitcoinStore bitcoinStore, Uri baseUri, EndPoint torSocks5EndPoint)
+			: base(network, bitcoinStore, baseUri, torSocks5EndPoint)
+		{
+		}
+
+		public async Task SleepAsync()
+		{
+			Interlocked.CompareExchange(ref _running, 2, 1); // If running, make it stopping.
+			Cancel?.Cancel();
+			while (Interlocked.CompareExchange(ref _running, 3, 0) == 2)
+			{
+				await Task.Delay(50);
+			}
+			Cancel?.Dispose();
+			Cancel = null;
+		}
+
+		public void Resume(TimeSpan requestInterval, TimeSpan feeQueryRequestInterval, int maxFiltersToSyncAtInitialization)
+		{
+			Interlocked.CompareExchange(ref _running, 3, 1); // if stopped, make it running
+			Cancel = new CancellationTokenSource();
+			Start(requestInterval, feeQueryRequestInterval, maxFiltersToSyncAtInitialization);
+		}
+	}
+}

--- a/Chaincase.Common/Global.cs
+++ b/Chaincase.Common/Global.cs
@@ -571,11 +571,6 @@ namespace Chaincase.Common
                     Synchronizer.Resume(requestInterval, TimeSpan.FromMinutes(5), maxFiltSyncCount);
                     Logger.LogInfo("Global.OnResuming():Start synchronizing filters...");
 
-                    if (Wallet?.ChaumianClient is { })
-                    {
-                        Synchronizer.ResponseArrived += Wallet.ChaumianClient.Synchronizer_ResponseArrivedAsync;
-                    }
-
                     if (SleepingCoins is { })
                     {
                         await Wallet.ChaumianClient.QueueCoinsToMixAsync(SleepingCoins);

--- a/Chaincase.Common/Global.cs
+++ b/Chaincase.Common/Global.cs
@@ -35,7 +35,6 @@ namespace Chaincase.Common
     public class Global
     {
         public string DataDir { get; }
-        public string TorLogsFile { get; }
 
         public BitcoinStore BitcoinStore { get; private set; }
         public Config Config { get; private set; }
@@ -79,7 +78,6 @@ namespace Chaincase.Common
                 Directory.CreateDirectory(DataDir);
                 Config = new Config(Path.Combine(DataDir, "Config.json"));
                 UiConfig = new UiConfig(Path.Combine(DataDir, "UiConfig.json"));
-                TorLogsFile = Path.Combine(DataDir, "TorLogs.txt");
 
                 Logger.InitializeDefaults(Path.Combine(DataDir, "Logs.txt"));
 

--- a/Chaincase.sln
+++ b/Chaincase.sln
@@ -10,15 +10,15 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WalletWasabi.Standard", "Wa
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chaincase.Common", "Chaincase.Common\Chaincase.Common.csproj", "{96670874-0C12-47C2-94A3-4B7CA7DBCED4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chaincase.Android", "Chaincase.Android\Chaincase.Android.csproj", "{DEE5F322-CA7E-40A6-A727-821A1EE262EE}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chaincase.UI", "Chaincase.UI\Chaincase.UI.csproj", "{15DF9C65-C954-4264-8B87-EF1D07B26D3B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chaincase.SSB", "Chaincase.SSB\Chaincase.SSB.csproj", "{396B25F5-ACC6-4718-A5F8-DADC52FCFC2E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.iOS.Tor", "Xamarin.iOS.Tor\Xamarin.iOS.Tor.csproj", "{4B9C81E8-049C-425D-BD7A-BFBF586A7F64}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.iOS.Tor.Tests", "Xamarin.iOS.Tor.Tests\Xamarin.iOS.Tor.Tests.csproj", "{AB0BE8BB-12F5-438B-A850-F5409B78654F}"
+Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "Chaincase.Android", "Chaincase.Android\Chaincase.Android.csproj", "{945B448E-EA19-4C18-83C7-AD9312DCD89E}"
+EndProject
+Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "Xamarin.iOS.Tor.Tests", "Xamarin.iOS.Tor.Tests\Xamarin.iOS.Tor.Tests.csproj", "{8F7B7E7F-3A69-47F4-9015-087CF3FD1622}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -109,8 +109,6 @@ Global
 		{96670874-0C12-47C2-94A3-4B7CA7DBCED4}.Release|x64.Build.0 = Release|Any CPU
 		{96670874-0C12-47C2-94A3-4B7CA7DBCED4}.Release|x86.ActiveCfg = Release|Any CPU
 		{96670874-0C12-47C2-94A3-4B7CA7DBCED4}.Release|x86.Build.0 = Release|Any CPU
-		{DEE5F322-CA7E-40A6-A727-821A1EE262EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{DEE5F322-CA7E-40A6-A727-821A1EE262EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{464A7AE3-7950-4FAC-9FE0-10B9D055E9F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{464A7AE3-7950-4FAC-9FE0-10B9D055E9F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{464A7AE3-7950-4FAC-9FE0-10B9D055E9F0}.Debug|iPhone.ActiveCfg = Debug|Any CPU
@@ -183,26 +181,28 @@ Global
 		{4B9C81E8-049C-425D-BD7A-BFBF586A7F64}.Release|x64.Build.0 = Release|Any CPU
 		{4B9C81E8-049C-425D-BD7A-BFBF586A7F64}.Release|x86.ActiveCfg = Release|Any CPU
 		{4B9C81E8-049C-425D-BD7A-BFBF586A7F64}.Release|x86.Build.0 = Release|Any CPU
-		{AB0BE8BB-12F5-438B-A850-F5409B78654F}.Debug|Any CPU.ActiveCfg = Debug|iPhone
-		{AB0BE8BB-12F5-438B-A850-F5409B78654F}.Debug|Any CPU.Build.0 = Debug|iPhone
-		{AB0BE8BB-12F5-438B-A850-F5409B78654F}.Debug|iPhone.ActiveCfg = Debug|iPhone
-		{AB0BE8BB-12F5-438B-A850-F5409B78654F}.Debug|iPhone.Build.0 = Debug|iPhone
-		{AB0BE8BB-12F5-438B-A850-F5409B78654F}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
-		{AB0BE8BB-12F5-438B-A850-F5409B78654F}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
-		{AB0BE8BB-12F5-438B-A850-F5409B78654F}.Debug|x64.ActiveCfg = Debug|iPhone
-		{AB0BE8BB-12F5-438B-A850-F5409B78654F}.Debug|x64.Build.0 = Debug|iPhone
-		{AB0BE8BB-12F5-438B-A850-F5409B78654F}.Debug|x86.ActiveCfg = Debug|iPhone
-		{AB0BE8BB-12F5-438B-A850-F5409B78654F}.Debug|x86.Build.0 = Debug|iPhone
-		{AB0BE8BB-12F5-438B-A850-F5409B78654F}.Release|Any CPU.ActiveCfg = Release|iPhone
-		{AB0BE8BB-12F5-438B-A850-F5409B78654F}.Release|Any CPU.Build.0 = Release|iPhone
-		{AB0BE8BB-12F5-438B-A850-F5409B78654F}.Release|iPhone.ActiveCfg = Release|iPhone
-		{AB0BE8BB-12F5-438B-A850-F5409B78654F}.Release|iPhone.Build.0 = Release|iPhone
-		{AB0BE8BB-12F5-438B-A850-F5409B78654F}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
-		{AB0BE8BB-12F5-438B-A850-F5409B78654F}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
-		{AB0BE8BB-12F5-438B-A850-F5409B78654F}.Release|x64.ActiveCfg = Release|iPhone
-		{AB0BE8BB-12F5-438B-A850-F5409B78654F}.Release|x64.Build.0 = Release|iPhone
-		{AB0BE8BB-12F5-438B-A850-F5409B78654F}.Release|x86.ActiveCfg = Release|iPhone
-		{AB0BE8BB-12F5-438B-A850-F5409B78654F}.Release|x86.Build.0 = Release|iPhone
+		{945B448E-EA19-4C18-83C7-AD9312DCD89E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{945B448E-EA19-4C18-83C7-AD9312DCD89E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8F7B7E7F-3A69-47F4-9015-087CF3FD1622}.Debug|Any CPU.ActiveCfg = Debug|iPhone
+		{8F7B7E7F-3A69-47F4-9015-087CF3FD1622}.Debug|Any CPU.Build.0 = Debug|iPhone
+		{8F7B7E7F-3A69-47F4-9015-087CF3FD1622}.Debug|iPhone.ActiveCfg = Debug|iPhone
+		{8F7B7E7F-3A69-47F4-9015-087CF3FD1622}.Debug|iPhone.Build.0 = Debug|iPhone
+		{8F7B7E7F-3A69-47F4-9015-087CF3FD1622}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
+		{8F7B7E7F-3A69-47F4-9015-087CF3FD1622}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
+		{8F7B7E7F-3A69-47F4-9015-087CF3FD1622}.Debug|x64.ActiveCfg = Debug|iPhone
+		{8F7B7E7F-3A69-47F4-9015-087CF3FD1622}.Debug|x64.Build.0 = Debug|iPhone
+		{8F7B7E7F-3A69-47F4-9015-087CF3FD1622}.Debug|x86.ActiveCfg = Debug|iPhone
+		{8F7B7E7F-3A69-47F4-9015-087CF3FD1622}.Debug|x86.Build.0 = Debug|iPhone
+		{8F7B7E7F-3A69-47F4-9015-087CF3FD1622}.Release|Any CPU.ActiveCfg = Release|iPhone
+		{8F7B7E7F-3A69-47F4-9015-087CF3FD1622}.Release|Any CPU.Build.0 = Release|iPhone
+		{8F7B7E7F-3A69-47F4-9015-087CF3FD1622}.Release|iPhone.ActiveCfg = Release|iPhone
+		{8F7B7E7F-3A69-47F4-9015-087CF3FD1622}.Release|iPhone.Build.0 = Release|iPhone
+		{8F7B7E7F-3A69-47F4-9015-087CF3FD1622}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
+		{8F7B7E7F-3A69-47F4-9015-087CF3FD1622}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
+		{8F7B7E7F-3A69-47F4-9015-087CF3FD1622}.Release|x64.ActiveCfg = Release|iPhone
+		{8F7B7E7F-3A69-47F4-9015-087CF3FD1622}.Release|x64.Build.0 = Release|iPhone
+		{8F7B7E7F-3A69-47F4-9015-087CF3FD1622}.Release|x86.ActiveCfg = Release|iPhone
+		{8F7B7E7F-3A69-47F4-9015-087CF3FD1622}.Release|x86.Build.0 = Release|iPhone
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Chaincase/Chaincase.csproj
+++ b/Chaincase/Chaincase.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="ReactiveUI.XamForms" Version="13.2.2" />
     <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
-    <PackageReference Include="NBitcoin" Version="5.0.75" />
+    <PackageReference Include="NBitcoin" Version="5.0.76" />
     <PackageReference Include="ReactiveUI" Version="13.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.12" />
   </ItemGroup>


### PR DESCRIPTION
A huge source of many crashes that I thought were tor related were from the Synchronizer getting handled as a dependency incorrectly. I would dispose of the old and create a new but without changing the dependencies in lower layers. This PR attempts to fix that by making synchronizer a singleton in global that can sleep and resume.

~This PR introduced another bug where if the app was launched, quickly slept, then resumed the Coinjoin screen never updates even if the backend shows as connected. That must be fixed before this is merged.~ < fixed @ ee316e0