### PR TITLE
Prevent sleeping the app while idle

### DIFF
--- a/Chaincase.Android/MainActivity.cs
+++ b/Chaincase.Android/MainActivity.cs
@@ -7,6 +7,7 @@ using Chaincase.Common.Contracts;
 using Chaincase.Common.Xamarin;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.MobileBlazorBindings.WebView.Android;
+using Android.Views;
 
 namespace Chaincase.Droid
 {
@@ -18,6 +19,7 @@ namespace Chaincase.Droid
 		protected override void OnCreate(Bundle savedInstanceState)
 		{
 			BlazorHybridAndroid.Init();
+			this.Window.SetFlags(WindowManagerFlags.KeepScreenOn, WindowManagerFlags.KeepScreenOn);
 			var fileProvider = new AssetFileProvider(Assets, "wwwroot");
 
 			base.OnCreate(savedInstanceState);

--- a/Chaincase.Android/Properties/AndroidManifest.xml
+++ b/Chaincase.Android/Properties/AndroidManifest.xml
@@ -4,4 +4,5 @@
 	<application android:label="Chaincase.Android"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
+	<uses-permission android:name="android.permission.WAKE_LOCK" />
 </manifest>

--- a/Chaincase.iOS/AppDelegate.cs
+++ b/Chaincase.iOS/AppDelegate.cs
@@ -50,7 +50,7 @@ namespace Chaincase.iOS
             UNUserNotificationCenter.Current.Delegate = 
                 formsApp.ServiceProvider.GetService<iOSNotificationReceiver>();
             LoadApplication(formsApp);
-
+            UIApplication.SharedApplication.IdleTimerDisabled = true;
             return base.FinishedLaunching(app, options);
         }
 


### PR DESCRIPTION
Users leave the app idle to sync with the network and during the final minutes of a coinjoin. The app needs to stay open during these times if a user deliberately leaves it open.