### PR TITLE
sync from recent height on new wallet

### DIFF
--- a/Chaincase.Common/Chaincase.Common.csproj
+++ b/Chaincase.Common/Chaincase.Common.csproj
@@ -16,7 +16,7 @@
     <ItemGroup>
       <PackageReference Include="ReactiveUI" Version="13.2.2" />
       <PackageReference Include="ReactiveUI.Blazor" Version="13.2.2" />
-      <PackageReference Include="NBitcoin" Version="5.0.76" />
+      <PackageReference Include="NBitcoin" Version="5.0.83" />
     </ItemGroup>
     <ItemGroup>
       <Folder Include="Models\" />

--- a/Chaincase.Common/Models/LatestMatureHeaderResponse.cs
+++ b/Chaincase.Common/Models/LatestMatureHeaderResponse.cs
@@ -1,0 +1,19 @@
+using System;
+using NBitcoin;
+using Newtonsoft.Json;
+using WalletWasabi.JsonConverters;
+
+namespace Chaincase.Common.Models
+{
+	public class LatestMatureHeaderResponse
+	{
+		[JsonConverter(typeof(Uint256JsonConverter))]
+		public uint256 BlockHash { get; set; }
+
+		[JsonConverter(typeof(Uint256JsonConverter))]
+		public uint256 PrevHash { get; set; }
+
+		public int Height { get; set; }
+		public DateTime Time { get; set; }
+	}
+}

--- a/Chaincase.Common/Services/ChaincaseClient.cs
+++ b/Chaincase.Common/Services/ChaincaseClient.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Chaincase.Common.Models;
+using WalletWasabi.Bases;
+using WalletWasabi.Helpers;
+
+namespace Chaincase.Common.Services
+{
+	public class ChaincaseClient : TorDisposableBase
+	{
+		/// <inheritdoc/>
+		public ChaincaseClient(Func<Uri> baseUriAction, EndPoint torSocks5EndPoint) : base(baseUriAction, torSocks5EndPoint)
+		{
+		}
+
+		public static ushort ApiVersion { get; private set; } = ushort.Parse(Constants.BackendMajorVersion);
+
+		// <remarks>
+		/// Throws OperationCancelledException if <paramref name="cancel"/> is set.
+		/// </remarks>
+		public async Task<LatestMatureHeaderResponse> GetLatestMatureHeader(CancellationToken cancel = default)
+		{
+			using var response = await TorClient.SendAndRetryAsync(
+				HttpMethod.Get,
+				HttpStatusCode.OK,
+				$"/api/v{ApiVersion}/btc/blockchain/latest-mature-header",
+				cancel: cancel);
+			if (response.StatusCode == HttpStatusCode.NoContent)
+			{
+				return null;
+			}
+			if (response.StatusCode != HttpStatusCode.OK)
+			{
+				await response.ThrowRequestExceptionFromContentAsync();
+			}
+
+			using HttpContent content = response.Content;
+			var ret = await content.ReadAsJsonAsync<LatestMatureHeaderResponse>();
+			return ret;
+		}
+	}
+}

--- a/Chaincase.UI/ViewModels/NewPasswordViewModel.cs
+++ b/Chaincase.UI/ViewModels/NewPasswordViewModel.cs
@@ -9,6 +9,9 @@ using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Helpers;
 using WalletWasabi.Wallets;
 using System.ComponentModel.DataAnnotations;
+using WalletWasabi.Stores;
+using WalletWasabi.Blockchain.Blocks;
+using System;
 
 namespace Chaincase.UI.ViewModels
 {
@@ -18,6 +21,8 @@ namespace Chaincase.UI.ViewModels
         private readonly Config _config;
         private readonly UiConfig _uiConfig;
         private readonly SensitiveStorage _storage;
+        private readonly BitcoinStore _bitcoinStore;
+        private readonly ChaincaseSynchronizer _synchronizer;
 
         public const int PasswordMinLength = 8;
 
@@ -25,16 +30,35 @@ namespace Chaincase.UI.ViewModels
         [MinLength(PasswordMinLength, ErrorMessage = "Make it 8 or more characters")]
         public string Password { get; set; }
 
-        public NewPasswordViewModel(ChaincaseWalletManager walletManager, Config config, UiConfig uiConfig, SensitiveStorage storage)
+        public NewPasswordViewModel(ChaincaseWalletManager walletManager, Config config, UiConfig uiConfig, SensitiveStorage storage, BitcoinStore bitcoinStore, ChaincaseSynchronizer sync)
         {
             _walletManager = walletManager;
             _config = config;
             _uiConfig = uiConfig;
             _storage = storage;
+            _bitcoinStore = bitcoinStore;
+            _synchronizer = sync;
         }
+
         public async Task SetPasswordAsync(string password)
         {
             Mnemonic seedWords = null;
+
+            ChaincaseClient client = new ChaincaseClient(_config.GetCurrentBackendUri, _config.TorSocks5EndPoint);
+            var res = await client.GetLatestMatureHeader();
+            var header = new SmartHeader(res.BlockHash, res.PrevHash, (uint)(int)res.Height, res.Time);
+            await _synchronizer.StopAsync();
+            await _bitcoinStore.IndexStore.ResetFromHeaderAsync(header);
+            var requestInterval = TimeSpan.FromSeconds(30);
+            if (_config.Network == Network.RegTest)
+            {
+                requestInterval = TimeSpan.FromSeconds(5);
+            }
+
+            int maxFiltSyncCount = _config.Network == Network.Main ? 1000 : 10000; // On testnet, filters are empty, so it's faster to query them together
+
+            _synchronizer.Start(requestInterval, TimeSpan.FromMinutes(5), maxFiltSyncCount);
+
             await Task.Run(() =>
             {
                 // Here we are not letting anything that will be autocorrected later.
@@ -44,6 +68,7 @@ namespace Chaincase.UI.ViewModels
                 string walletFilePath = Path.Combine(_walletManager.WalletDirectories.WalletsDir, $"{_config.Network}.json");
                 KeyManager.CreateNew(out seedWords, password, walletFilePath);
             });
+
             await _storage.SetSeedWords(password, seedWords.ToString());
 
             // this should not be a config

--- a/Chaincase/Chaincase.csproj
+++ b/Chaincase/Chaincase.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="ReactiveUI.XamForms" Version="13.2.2" />
     <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
-    <PackageReference Include="NBitcoin" Version="5.0.76" />
+    <PackageReference Include="NBitcoin" Version="5.0.83" />
     <PackageReference Include="ReactiveUI" Version="13.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.12" />
   </ItemGroup>


### PR DESCRIPTION
So that when you onboard for the first time you don't have to wait for filters.

if creating a new wallet, just reset the `BitcoinStore` and `IndexStore`s to sync most recent mature block filters

for some reason this appears not to connect to peers after the reset but it appears to reset the `BitcoinStore` on new wallet. I wonder if the `P2pBlockProvider` gets mad that the `WasabiSynchronizer` stops.

It also crashed on new wallet for me, but that may have been related to the debugger