### PR TITLE
show tx time relative to now instead of utc

### DIFF
--- a/Chaincase.UI/ViewModels/TransactionViewModel.cs
+++ b/Chaincase.UI/ViewModels/TransactionViewModel.cs
@@ -32,7 +32,7 @@ namespace Chaincase.UI.ViewModels
 			const int DAY = 24 * HOUR;
 			const int MONTH = 30 * DAY;
 
-			var ts = new TimeSpan(DateTime.UtcNow.Ticks - Model.DateTime.Ticks);
+			var ts = new TimeSpan(DateTime.Now.Ticks - Model.DateTime.Ticks);
 			double delta = Math.Abs(ts.TotalSeconds);
 
 			if (delta < 1 * MINUTE)


### PR DESCRIPTION
on the overview page