### PR TITLE
SSB: Use Actual Tor

### DIFF
--- a/Chaincase.SSB/DesktopTorManager.cs
+++ b/Chaincase.SSB/DesktopTorManager.cs
@@ -1,0 +1,33 @@
+﻿using System.Threading.Tasks;
+using Chaincase.Common;
+using Chaincase.Common.Contracts;
+using WalletWasabi.TorSocks5;
+
+namespace Chaincase.SSB
+{
+	public class DesktopTorManager : ITorManager
+	{
+		private readonly Config _config;
+		private TorProcessManager _torProcessManager;
+
+		public DesktopTorManager(Config config)
+		{
+			_config = config;
+		}
+
+		public TorState State => _torProcessManager?.IsRunning is true ? TorState.Connected : TorState.None;
+		public Task StopAsync()
+		{
+			return _torProcessManager.StopAsync();
+		}
+
+		public Task StartAsync(bool ensureRunning, string dataDir)
+		{
+			_torProcessManager ??= _config.UseTor
+				? new TorProcessManager(_config.TorSocks5EndPoint, null)
+				: TorProcessManager.Mock();
+			_torProcessManager.Start(ensureRunning, dataDir);
+			return Task.CompletedTask;
+		}
+	}
+}

--- a/Chaincase.SSB/DesktopTorManager.cs
+++ b/Chaincase.SSB/DesktopTorManager.cs
@@ -15,7 +15,7 @@ namespace Chaincase.SSB
 			_config = config;
 		}
 
-		public TorState State => _torProcessManager?.IsRunning is true ? TorState.Connected : TorState.None;
+		public TorState State => _torProcessManager?.IsRunning ? TorState.Connected : TorState.None;
 		public Task StopAsync()
 		{
 			return _torProcessManager.StopAsync();

--- a/Chaincase.SSB/DesktopTorManager.cs
+++ b/Chaincase.SSB/DesktopTorManager.cs
@@ -15,7 +15,7 @@ namespace Chaincase.SSB
 			_config = config;
 		}
 
-		public TorState State => _torProcessManager?.IsRunning ? TorState.Connected : TorState.None;
+		public TorState State => _torProcessManager?.IsRunning is true ? TorState.Connected : TorState.None;
 		public Task StopAsync()
 		{
 			return _torProcessManager.StopAsync();

--- a/Chaincase.SSB/Startup.cs
+++ b/Chaincase.SSB/Startup.cs
@@ -42,7 +42,7 @@ namespace Chaincase.SSB
 			// typically OS specific but web specific in SSB
 			services.AddScoped<IHsmStorage, JsInteropSecureConfigProvider>();
 			services.AddSingleton<INotificationManager, MockNotificationManager>();
-			services.AddSingleton<ITorManager, MockTorManager>();
+			services.AddSingleton<ITorManager, DesktopTorManager>();
 
 			services.AddBlazorDownloadFile();
 		}


### PR DESCRIPTION
This makes the SSB build use the same Tor runner as Wasabi. IMO it is better to be closer to the real thing on all platforms.  Works like a charm after https://github.com/chaincase-app/WalletWasabi.Standard/pull/4 is merged